### PR TITLE
Fix 401 Unauthorized error in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,9 @@ jobs:
   build:
     name: Build
     runs-on: macos-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -43,8 +46,8 @@ jobs:
       - name: Add Gradle Properties
         if: steps.version.outputs.is_semver == 'true'
         env:
-          GITHUB_PACKAGES_USER_NAME: ${{ secrets.GH_PACKAGES_USER_NAME }}
-          GITHUB_PACKAGES_PASSWORD: ${{ secrets.GH_PACKAGES_PASSWORD }}
+          GITHUB_PACKAGES_USER_NAME: ${{ github.actor }}
+          GITHUB_PACKAGES_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           echo "githubPackagesUsername=${GITHUB_PACKAGES_USER_NAME}" >> gradle.properties


### PR DESCRIPTION
The build was failing with a 401 Unauthorized error when trying to publish artifacts to GitHub Packages. This was likely due to missing or invalid `GH_PACKAGES_USER_NAME` / `GH_PACKAGES_PASSWORD` secrets.

This change switches the authentication mechanism to use the automatic `GITHUB_TOKEN` provided by GitHub Actions, which is the recommended way to publish packages within the same repository context. It also explicitly grants `packages: write` permission to the workflow job.

---
*PR created automatically by Jules for task [363765594937754587](https://jules.google.com/task/363765594937754587) started by @IdanAizikNissim*